### PR TITLE
Add Date in string format, and prevent error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,12 @@
  * @return {Date} The cloned date object.
  */
 module.exports = function cloneDate(date) {
+    // prevent error message in case of an invalid entry
+    try {
+        date.getTime();
+    } catch (error) {
+        date = new Date(date);
+    }
     var c = new Date();
     c.setTime(date.getTime());
     return c;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.13",
   "description": "Clone date objects.",
   "main": "lib/index.js",
+  "contributors": [
+    "Desiderio Silva <desideriotbs@gmail.com> (https://github.com/dsilva01)"
+ ],
   "directories": {
     "example": "example"
   },


### PR DESCRIPTION
> > > ```js
> > > const cloneDate = require("clone-data")
> > > 
> > > console.log(cloneDate("1970-05-10")); 
> > > 
> > > console.log(cloneDate("dfs"));
> > > ```
> > > 
> > > 
> > >     
> > >       
> > >     
> > > 
> > >       
> > >     
> > > 
> > >     
> > >   
> > > The expected output is `the Date`, as `1970-05-10` is a date. It logs `Error` instead.
> > > The expected output is `Invalid Date`, as `dfs` is a string. It logs `Error` instead.

